### PR TITLE
Refactor CategoriesController to use AuthorizedControllerBase

### DIFF
--- a/src/Shared.Auth/Controllers/AuthorizedControllerBase.cs
+++ b/src/Shared.Auth/Controllers/AuthorizedControllerBase.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Shared.Auth.Controllers
+{
+    [ApiController]
+    [Authorize(Roles = "clear-budget")]
+    public abstract class AuthorizedControllerBase : ControllerBase
+    {
+        protected Guid UserId
+        {
+            get
+            {
+                var idClaim = User.FindFirst("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier")?.Value;
+                if (Guid.TryParse(idClaim, out var userId))
+                {
+                    return userId;
+                }
+
+                throw new UnauthorizedAccessException("Invalid or missing user ID in token.");
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
The CategoriesController now inherits from AuthorizedControllerBase, centralizing user ID retrieval through the new UserId property. The GetUserIdFromToken method has been removed, reducing redundancy and improving maintainability. Additionally, the [ApiController] and [Authorize(Roles = "clear-budget")] attributes have been moved to the base class for consistent behavior across derived controllers.